### PR TITLE
Derive

### DIFF
--- a/habs/derive/PKGBUILD
+++ b/habs/derive/PKGBUILD
@@ -1,0 +1,35 @@
+# Maintainer: Arch Haskell Team <arch-haskell@haskell.org>
+_hkgname=derive
+pkgname=derive
+pkgver=2.4.2
+pkgrel=1
+pkgdesc="A program and library to derive instances for data types"
+url="http://hackage.haskell.org/package/${_hkgname}"
+license=('custom:BSD3')
+arch=('i686' 'x86_64')
+makedepends=()
+depends=('gmp' 'ghc' 'haskell-bytestring=0.9.1.7' 'haskell-containers=0.3.0.0' 'haskell-directory=1.0.1.1' 'haskell-filepath=1.1.0.4' 'haskell-haskell-src-exts<1.11' 'haskell-pretty=1.0.1.1' 'haskell-process=1.0.1.3' 'haskell-syb=0.1.0.2' 'haskell-template-haskell=2.4.0.1' 'haskell-transformers<0.3' 'haskell-uniplate<1.7')
+options=('strip')
+source=(http://hackage.haskell.org/packages/archive/${_hkgname}/${pkgver}/${_hkgname}-${pkgver}.tar.gz)
+install=${pkgname}.install
+md5sums=('b51c1f79a25d20173520e283e10c7937')
+build() {
+    cd ${srcdir}/${_hkgname}-${pkgver}
+    runhaskell Setup configure -O --enable-split-objs --enable-shared \
+       --prefix=/usr --docdir=/usr/share/doc/${pkgname} --libsubdir=\$compiler/site-local/\$pkgid
+    runhaskell Setup build
+    runhaskell Setup haddock
+    runhaskell Setup register   --gen-script
+    runhaskell Setup unregister --gen-script
+    sed -i -r -e "s|ghc-pkg.*unregister[^ ]* |&'--force' |" unregister.sh
+}
+package() {
+    cd ${srcdir}/${_hkgname}-${pkgver}
+    install -D -m744 register.sh   ${pkgdir}/usr/share/haskell/${pkgname}/register.sh
+    install    -m744 unregister.sh ${pkgdir}/usr/share/haskell/${pkgname}/unregister.sh
+    install -d -m755 ${pkgdir}/usr/share/doc/ghc/html/libraries
+    ln -s /usr/share/doc/${pkgname}/html ${pkgdir}/usr/share/doc/ghc/html/libraries/${_hkgname}
+    runhaskell Setup copy --destdir=${pkgdir}
+    install -D -m644 LICENSE ${pkgdir}/usr/share/licenses/${pkgname}/LICENSE
+    rm -f ${pkgdir}/usr/share/doc/${pkgname}/LICENSE
+}

--- a/habs/derive/derive.install
+++ b/habs/derive/derive.install
@@ -1,0 +1,18 @@
+HS_DIR=usr/share/haskell/derive
+post_install() {
+  ${HS_DIR}/register.sh
+  (cd usr/share/doc/ghc/html/libraries; ./gen_contents_index)
+}
+pre_upgrade() {
+  ${HS_DIR}/unregister.sh
+}
+post_upgrade() {
+  ${HS_DIR}/register.sh
+  (cd usr/share/doc/ghc/html/libraries; ./gen_contents_index)
+}
+pre_remove() {
+  ${HS_DIR}/unregister.sh
+}
+post_remove() {
+  (cd usr/share/doc/ghc/html/libraries; ./gen_contents_index)
+}


### PR DESCRIPTION
This version natively depends on the latest haskell-src-exts and should work as well on GHC7
