### PR TITLE
compact-string-fix

### DIFF
--- a/habs/haskell-compact-string-fix/PKGBUILD
+++ b/habs/haskell-compact-string-fix/PKGBUILD
@@ -1,0 +1,35 @@
+# Maintainer: Fabio Riga <rifabio@gmail.com>
+_hkgname=compact-string-fix
+pkgname=haskell-compact-string-fix
+pkgver=0.3.1
+pkgrel=4
+pkgdesc="Same as compact-string except with a small fix so it builds on ghc-6.12"
+url="http://hackage.haskell.org/package/${_hkgname}"
+license=('custom:BSD3')
+arch=('i686' 'x86_64')
+makedepends=()
+depends=('ghc' 'haskell-bytestring=0.9.1.10')
+options=('strip')
+source=(http://hackage.haskell.org/packages/archive/${_hkgname}/${pkgver}/${_hkgname}-${pkgver}.tar.gz)
+install=${pkgname}.install
+md5sums=('4402c9b3e4f5b77fbc40b6cb900cb232')
+build() {
+    cd ${srcdir}/${_hkgname}-${pkgver}
+    runhaskell Setup configure -O ${PKGBUILD_HASKELL_ENABLE_PROFILING:+-p } --enable-split-objs --enable-shared \
+       --prefix=/usr --docdir=/usr/share/doc/${pkgname} --libsubdir=\$compiler/site-local/\$pkgid
+    runhaskell Setup build
+    runhaskell Setup haddock
+    runhaskell Setup register   --gen-script
+    runhaskell Setup unregister --gen-script
+    sed -i -r -e "s|ghc-pkg.*unregister[^ ]* |&'--force' |" unregister.sh
+}
+package() {
+    cd ${srcdir}/${_hkgname}-${pkgver}
+    install -D -m744 register.sh   ${pkgdir}/usr/share/haskell/${pkgname}/register.sh
+    install    -m744 unregister.sh ${pkgdir}/usr/share/haskell/${pkgname}/unregister.sh
+    install -d -m755 ${pkgdir}/usr/share/doc/ghc/html/libraries
+    ln -s /usr/share/doc/${pkgname}/html ${pkgdir}/usr/share/doc/ghc/html/libraries/${_hkgname}
+    runhaskell Setup copy --destdir=${pkgdir}
+    install -D -m644 LICENSE ${pkgdir}/usr/share/licenses/${pkgname}/LICENSE
+    rm -f ${pkgdir}/usr/share/doc/${pkgname}/LICENSE
+}

--- a/habs/haskell-compact-string-fix/haskell-compact-string-fix.install
+++ b/habs/haskell-compact-string-fix/haskell-compact-string-fix.install
@@ -1,0 +1,18 @@
+HS_DIR=usr/share/haskell/haskell-compact-string-fix
+post_install() {
+  ${HS_DIR}/register.sh
+  (cd usr/share/doc/ghc/html/libraries; ./gen_contents_index)
+}
+pre_upgrade() {
+  ${HS_DIR}/unregister.sh
+}
+post_upgrade() {
+  ${HS_DIR}/register.sh
+  (cd usr/share/doc/ghc/html/libraries; ./gen_contents_index)
+}
+pre_remove() {
+  ${HS_DIR}/unregister.sh
+}
+post_remove() {
+  (cd usr/share/doc/ghc/html/libraries; ./gen_contents_index)
+}


### PR DESCRIPTION
Hi,

it's needed by bson. I forgot it because it was present and quite updated in AUR. Now I will check if there's something in AUR that these packages depends on to include them in habs.

Cheers
Fabio
