### PR TITLE
[ghc-mod] byte-compile *.el files

### DIFF
--- a/patches/ghc-mod.pkgbuild
+++ b/patches/ghc-mod.pkgbuild
@@ -2,17 +2,17 @@ Index: habs/ghc-mod/PKGBUILD
 ===================================================================
 --- habs.orig/ghc-mod/PKGBUILD
 +++ habs/ghc-mod/PKGBUILD
-@@ -18,7 +18,8 @@ makedepends=("ghc=7.4.1-1"
-              "haskell-io-choice=0.0.1-8"
-              "haskell-regex-posix=0.95.2-2"
-              "haskell-syb=0.3.6.1-1"
--             "haskell-transformers=0.3.0.0-1")
-+             "haskell-transformers=0.3.0.0-1"
+@@ -17,7 +17,8 @@ makedepends=("ghc=7.4.2-1"
+              "haskell-io-choice=0.0.1-9"
+              "haskell-regex-posix=0.95.2-3"
+              "haskell-syb=0.3.6.1-2"
+-             "haskell-transformers=0.3.0.0-2")
++             "haskell-transformers=0.3.0.0-2"
 +             "emacs")
  depends=()
  options=('strip')
  source=("http://hackage.haskell.org/packages/archive/${_hkgname}/${pkgver}/${_hkgname}-${pkgver}.tar.gz")
-@@ -37,4 +38,15 @@ build() {
+@@ -36,4 +37,15 @@ build() {
  package() {
      cd ${srcdir}/${_hkgname}-${pkgver}
      runhaskell Setup copy --destdir=${pkgdir}


### PR DESCRIPTION
Maybe it would make sense to byte compile the *.el files and install them to a better place. Right now they are in /usr/share/ghc-mod-1.10.15, which means after every upgrade I have to manually copy and byte-compile them.
