### PR TITLE
Adapt "makeahpkg" script to devtools >= 20130525

### DIFF
--- a/makeahpkg
+++ b/makeahpkg
@@ -68,7 +68,7 @@ buildpkg() {
         msg "Skipping build in $PWD"
     else
         msg "Building in $PWD"
-        sudo setarch ${arch} makechrootpkg -u -d -l ${build_chrootdir} -r ${CHROOT_DIR} -- -i
+        sudo setarch ${arch} makechrootpkg -u -l ${build_chrootdir} -r ${CHROOT_DIR} -- -i
     fi
 }
 


### PR DESCRIPTION
This commit removes the "-d" flag of makechrootpkg in the makeahpkg
script to avoid the following error:

  ==> ERROR: No chroot dir defined, or invalid path ''

This is due to following commits in devtools that change the meaning
of "-d" command-line option of makechroot package:

The commit abba9f07a6d703cd97fc2d2bbd397072d5bf796d of devtools
removes the "add_to_db" feature of makechrootpkg script. It was set
with command-line "-d" flag.

The commit e77242c5393a5004fce42483c66f8256981f6ef5 of devtools adds
new features for additional bind mounts. It use command-line "-d"
and "-D" parameters, overriding previous meaning of "-d" option.

See:
https://projects.archlinux.org/devtools.git/commit/?id=abba9f07a6d703cd97fc2d2bbd397072d5bf796d
https://projects.archlinux.org/devtools.git/commit/?id=e77242c5393a5004fce42483c66f8256981f6ef5
