### PR TITLE
haskell-src-exts: set -mcpu flag for LLVM

### DIFF
--- a/patches/haskell-src-exts.pkgbuild
+++ b/patches/haskell-src-exts.pkgbuild
@@ -11,23 +11,13 @@ Index: habs/haskell-haskell-src-exts/PKGBUILD
  depends=("ghc=7.8.2-1"
           "haskell-cpphs=1.18.4-4")
  options=('strip' 'staticlibs')
-@@ -29,10 +29,17 @@ prepare() {
- 
- build() {
-     cd "${srcdir}/${_hkgname}-${pkgver}"
--    
-+
-+    if [ "${CARCH}" = "i686" ]; then
-+      CPUFLAG="-mcpu=i686"
-+    elif [ "${CARCH}" = "x86_64" ]; then
-+      CPUFLAG="-mcpu=x86-64"
-+    fi
-+
+@@ -32,7 +32,8 @@ build() {
+     
      runhaskell Setup configure -O --enable-library-profiling --enable-shared \
          --prefix=/usr --docdir="/usr/share/doc/${pkgname}" \
 -        --libsubdir=\$compiler/site-local/\$pkgid
 +        --libsubdir=\$compiler/site-local/\$pkgid \
-+        --ghc-options="-fllvm -optlc=${CPUFLAG}"
++        --ghc-options="-fllvm -optlc=-mcpu=$(uname -m | sed s/_/-/)"
      runhaskell Setup build
      runhaskell Setup haddock --hoogle --html
      runhaskell Setup register --gen-script


### PR DESCRIPTION
Normally LLVM autodetects the cpu of the machine it's building on and optimizes for it. This can cause the binary to crash when executed on a cpu different from the one it was built on, e.g. if the build cpu supports AVX instructions and the host does not.

In order to produce generic code `-mcpu=i686` or `-mcpu=x86-64` should be passed to `llc`.

Signed-off-by: Nicola Squartini tensor5@gmail.com
